### PR TITLE
Line length limit fortran compiler

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -60,7 +60,7 @@ COMPILER = gfortran
 F90C     = gfortran
 SFFLAGS =  -shared -fPIC
 
-FFLAGS =  -O3 -fopenmp -ffast-math -fmax-errors=4 -cpp
+FFLAGS =  -O3 -fopenmp -ffast-math -fmax-errors=4 -cpp -ffree-line-length-none
 DEBUGFLAGS = -cpp -g -fbounds-check -fbacktrace -ffree-line-length-none -fmax-errors=4 -ffpe-trap=invalid,overflow,zero -DDEBUG
 MODOUT =  -J$(OUTPUT_DIR)
 SMODOUT = -J$(DLL_DIR)


### PR DESCRIPTION
Hi, 

I am on a mac computer using the gfortran compiler version 11.3.0.
When compiling the code with ```make camb``` I got this error message
```
mkdir -p Release
gfortran -O3 -fopenmp -ffast-math -fmax-errors=4 -cpp -ffree-form -JRelease -IRelease/ -c constants.f90 -o Release/constants.o
gfortran -O3 -fopenmp -ffast-math -fmax-errors=4 -cpp -ffree-form -JRelease -IRelease/ -c inifile.f90 -o Release/inifile.o
gfortran -O3 -fopenmp -ffast-math -fmax-errors=4 -cpp -ffree-form -JRelease -IRelease/ -c mgcamb.f90 -o Release/mgcamb.o
mgcamb.f90:1087:132:

 1087 |             mg_cache%grhov_t = 3._dl*mg_par_cache%h0_Mpc**2*mg_par_cache%omegav*a**(-1.d0-3.d0*w0DE-3.d0*waDE)*Exp(3.d0*waDE*(a-1.d0))
      |                                                                                                                                    1
Error: Line truncated at (1) [-Werror=line-truncation]
mgcamb.f90:1087:132:

 1087 |             mg_cache%grhov_t = 3._dl*mg_par_cache%h0_Mpc**2*mg_par_cache%omegav*a**(-1.d0-3.d0*w0DE-3.d0*waDE)*Exp(3.d0*waDE*(a-1.d0))
      |                                                                                                                                    1
Error: Expected a right parenthesis in expression at (1)
f951: some warnings being treated as errors
make: *** [Release/mgcamb.o] Error 1
```

This is due to the line being longer than the limit of 132 characters. Adding the flag `-ffree-line-length-none` in the Makefile solved this compilation issue for me. 

